### PR TITLE
Added a plugin for fluxible to add copy methods to context

### DIFF
--- a/jasmine.json
+++ b/jasmine.json
@@ -1,6 +1,7 @@
 {
   "spec_dir": "spec",
   "spec_files": [
-    "copy-text_spec.js"
+    "copy-text_spec.js",
+    "copyTextPlugin_spec.js"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,10 @@
   "homepage": "https://github.com/1stdibs/copy-text#readme",
   "dependencies": {
     "dibs-endpoints": "~1.1.1",
+    "fluxible": "~1.0.3",
+    "fluxible-addons-react": "~0.2.2",
+    "react": "~0.14.5",
+    "react-dom": "~0.14.5",
     "reku": "~1.1.1",
     "server-vars": "~2.0.1",
     "underscore": "~1.8.3"

--- a/plugins/fluxible/copyTextPlugin.js
+++ b/plugins/fluxible/copyTextPlugin.js
@@ -1,0 +1,20 @@
+'use strict';
+
+var copyText = require('../../copy-text');
+
+module.exports = {
+    name: 'CopyTextPlugin',
+    plugContext: function () {
+        var copy = copyText();
+        function plug(context) {
+            var ownCopy = copy;
+            context.getCopy = function (key) { return ownCopy.get(key); };
+            context.extendCopy = function (morecopy) { ownCopy = copy.extend(morecopy); };
+        };
+        return {
+            plugComponentContext: plug,
+            plugActionContext: plug,
+            plugStoreContext: plug
+        };
+    }
+};

--- a/plugins/fluxible/helpers/copyContextTypes.js
+++ b/plugins/fluxible/helpers/copyContextTypes.js
@@ -1,0 +1,6 @@
+'use strict';
+var React = require('react');
+module.exports = {
+    getCopy: React.PropTypes.func.isRequired,
+    extendCopy: React.PropTypes.func.isRequired
+};

--- a/plugins/fluxible/helpers/provideContextWithCopy.js
+++ b/plugins/fluxible/helpers/provideContextWithCopy.js
@@ -1,0 +1,8 @@
+'use strict';
+var provideContext = require('fluxible-addons-react/provideContext');
+var copyContextTypes = require('./copyContextTypes');
+var _ = require('underscore');
+module.exports = function (Component, customContextTypes) {
+    customContextTypes = customContextTypes || {};
+    return provideContext(Component, _.extend(customContextTypes, copyContextTypes));
+};

--- a/spec/copyTextPlugin_spec.js
+++ b/spec/copyTextPlugin_spec.js
@@ -1,0 +1,32 @@
+'use strict';
+var copyText = require('../copy-text');
+var copyTextPlugin = require('../plugins/fluxible/copyTextPlugin');
+describe('copyTextPlugin', function () {
+    var plugs;
+    beforeEach(function () {
+        plugs = copyTextPlugin.plugContext();
+    });
+    it('should plug each type of context with same extending function', function () {
+        ['plugComponentContext', 'plugActionContext', 'plugStoreContext']
+            .forEach(function(ctx) {
+                expect(typeof plugs[ctx]).toEqual('function');
+            });
+        expect(plugs.plugComponentContext === plugs.plugActionContext 
+            && plugs.plugActionContext === plugs.plugStoreContext).toBe(true);
+    });
+    it('should be able to get globally set copy', function () {
+        var context = {};
+        copyText.addGlobalCopy({ copyKey: 'someCopy' });
+        plugs.plugActionContext(context);
+        expect(context.getCopy('copyKey')).toEqual('someCopy');
+    });
+    it('should be able to extend copy for a given context', function () {
+        var actionContext = {};
+        var componentContext = {};
+        plugs.plugActionContext(actionContext);
+        plugs.plugComponentContext(componentContext);
+        actionContext.extendCopy({ copyKeyTwo: 'moreCopy' });
+        expect(actionContext.getCopy('copyKeyTwo')).toEqual('moreCopy');
+        expect(componentContext.getCopy('copyKeyTwo')).toEqual('copyKeyTwo');
+    });
+});


### PR DESCRIPTION
### A Proposal for Copy Methods on Context

A fluxible plugin that would add the additional methods: `getCopy` and `extendCopy` to the contexts: `ComponentContext`, `ActionContext`, and `StoreContext` (**note:** not on FluxibleContext).

This would allow easy access to copy for react component, actions, and stores without having to pass it down through props and payloads. It's also easy to start using, using the `message-center.js` entry file from adminv2 as an example, all that's needed is:
```javascript
// ...
messageCenterApp.plug(require('copy-text/plugins/fluxible/copyTextPlugin'));
var context = messageCenterApp.createContext({ svCopyPath: 'mc.copy' });
// ...
```

Some catches downstream, when using `provideContext`, a second parameter should be passed that looks like...
```javascript
provideContext(SomeTopLevelComponent, {
    getCopy: React.PropTypes.function.isRequired,
    extendCopy: React.PropTypes.function.isRequired
});
```

Maybe I can add to the PR a helper that exports that object.

Also a user should add `contextTypes` to their component i.e.:
```javascript
SomeComponent.contextTypes = {
    executeAction: React.PropTypes.function.isRequired,
    getStore: React.PropTypes.function.isRequired,
    getCopy: React.PropTypes.function.isRequired,
    extendCopy: React.PropTypes.function.isRequired
};
```

Users only need to add the contextTypes that their component actually uses to reduce that boilerplate.

And that's all that's required to use the plugin....
```javascript
render() {
    return <h1>{this.context.getCopy('myTitleKey')}</h1>;
}
```

##### Additional notes
- I didn't make this it's own module since it's related to copy-text and also copy-text requires `dibs-endpoints` which makes this have to be closed-source...no point using up another closed-source repo for our quota
- not sure about `extendCopy` since each context instance gets it own copyText object, extending copy within a component would not be visible to actions **BUT** would be visible to child components (I'm pretty sure, since it's the same context getting passed down). Looking for feedback on that. Maybe not even include an `extendCopy` method?
- this PR is incomplete, still need to do/write tests

+@robrichard
+@jrdrg 
+@twhid 