### PR TITLE
FINDING-9267: Copy in contact dealer modal

### DIFF
--- a/copy-text.js
+++ b/copy-text.js
@@ -30,7 +30,7 @@ CopyText.prototype = {
         templateVars = assign({}, options.obj, {
             _copy: this.get.bind(this)
         });
-        text = template(text)(templateVars);
+        text = text ? template(text)(templateVars) : null;
         return text;
     },
     object: function () {


### PR DESCRIPTION
Always passing the text result through `lodash.template` means that even a falsy copyKey will be returned as a string - in this instance, `false` became `"false"`, which is evaluated as truthy

¯\\\_(ツ)\_/¯